### PR TITLE
Refactor database initialization to avoid build-time env requirement

### DIFF
--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,10 +1,23 @@
-import { drizzle } from 'drizzle-orm/postgres-js';
+import {drizzle} from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
-import { env } from '$env/dynamic/private';
+import {env} from '$env/dynamic/private';
 
-if (!env.DATABASE_URL) throw new Error('DATABASE_URL is not set');
+let database: ReturnType<typeof drizzle<typeof schema>> | null = null;
 
-const client = postgres(env.DATABASE_URL);
+export function getDb() {
+    if (database) {
+        return database;
+    }
 
-export const db = drizzle(client, { schema });
+    const connectionString = env.DATABASE_URL ?? process.env.DATABASE_URL;
+
+    if (!connectionString) {
+        throw new Error('DATABASE_URL is not set');
+    }
+
+    const client = postgres(connectionString);
+    database = drizzle(client, {schema});
+
+    return database;
+}

--- a/src/lib/server/db/recipe.ts
+++ b/src/lib/server/db/recipe.ts
@@ -1,4 +1,4 @@
-import {db} from "$lib/server/db/index";
+import {getDb} from "$lib/server/db/index";
 import {
     difficulty,
     difficultyToRecipe,
@@ -24,6 +24,7 @@ export async function createRecipe({
                                        tags,
                                        image
                                    }: CreateRecipeInput) {
+    const db = getDb();
     const result = await db.insert(recipes).values({
         title,
         description,
@@ -77,6 +78,7 @@ export async function updateRecipe({
                                        tags,
                                        image
                                    }: UpdateRecipeInput) {
+    const db = getDb();
     await db.update(recipes)
         .set({
             title,
@@ -126,6 +128,7 @@ export async function updateRecipe({
 }
 
 export async function getRecipes() {
+    const db = getDb();
     return db.select({
         ...getTableColumns(recipes),
         difficulty: difficulty.difficulty,
@@ -136,6 +139,7 @@ export async function getRecipes() {
 }
 
 export async function getFavoriteRecipes() {
+    const db = getDb();
     return db.select({
         ...getTableColumns(recipes),
         difficulty: difficulty.difficulty,
@@ -148,6 +152,7 @@ export async function getFavoriteRecipes() {
 }
 
 export async function getRecipeById(id: number) {
+    const db = getDb();
     const result = await db
         .select({
             ...getTableColumns(recipes),
@@ -162,6 +167,7 @@ export async function getRecipeById(id: number) {
 }
 
 export async function getRecipeFavoriteState(userId: string, recipeId: number) {
+    const db = getDb();
     const rows = await db
         .select({ favorite: favorite.favorite })
         .from(favorite)
@@ -171,22 +177,27 @@ export async function getRecipeFavoriteState(userId: string, recipeId: number) {
 }
 
 export async function getSteps(recipeId: number) {
+    const db = getDb();
     return db.select(getTableColumns(steps)).from(steps).where(eq(steps.recipeId, recipeId));
 }
 
 export async function getIngredients(recipeId: number) {
+    const db = getDb();
     return db.select(getTableColumns(ingredients)).from(ingredients).where(eq(ingredients.recipeId, recipeId));
 }
 
 export async function getTags(recipeId: number) {
+    const db = getDb();
     return db.select(getTableColumns(tagsTable)).from(tagsTable).where(eq(tagsTable.recipeId, recipeId));
 }
 
 export async function getDifficulties() {
+    const db = getDb();
     return db.select().from(difficulty).orderBy(difficulty.id);
 }
 
 export async function toggleRecipeFavorite(userId: string, recipeId: number) {
+    const db = getDb();
     return db.insert(favorite)
         .values({
             recipeId,

--- a/src/lib/server/db/user.ts
+++ b/src/lib/server/db/user.ts
@@ -1,14 +1,16 @@
-import {db} from "$lib/server/db/index";
+import {getDb} from "$lib/server/db/index";
 import {eq} from "drizzle-orm";
 import {user} from "$lib/server/db/schema";
 
 export async function saveProfile(userId: string, username: string, email: string, avatar: string) {
+    const db = getDb();
     return db.update(user)
         .set({username, email, avatar})
         .where(eq(user.id, userId));
 }
 
 export async function updatePassword(userId: string, passwordHash: string) {
+    const db = getDb();
     return db.update(user)
         .set({passwordHash})
         .where(eq(user.id, userId));


### PR DESCRIPTION
## Summary
- add a lazily initialized database getter so builds no longer require DATABASE_URL
- update authentication logic and login actions to obtain the database connection on demand
- adjust recipe and user data helpers to use the new getter instead of importing a module-level client

## Testing
- npm run build